### PR TITLE
Add sound effect on reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Page Load Alert Chrome Extension
 
-This extension displays a simple alert whenever a tab reloads and the extension is enabled for that tab.
+This extension plays a short sound whenever a tab reloads and the extension is enabled for that tab.
 
 ## Installation
 1. Open Chrome and navigate to `chrome://extensions`.
@@ -8,7 +8,7 @@ This extension displays a simple alert whenever a tab reloads and the extension 
 3. Click **Load unpacked** and select this directory.
 
 ## Usage
-- Click the extension's toolbar icon to toggle alerts for the active tab.
+ - Click the extension's toolbar icon to toggle sounds for the active tab.
 - When enabled, the badge displays **ON** and stays visible even after the page reloads.
-- A stub alert message will appear each time the page reloads on that tab.
+- A sound effect will play each time the page reloads on that tab.
 - The setting is disabled by default and remembered per tab until the tab is closed.

--- a/background.js
+++ b/background.js
@@ -49,21 +49,16 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   }
 });
 
-function playSound(tabId) {
-  const url = chrome.runtime.getURL('sound.mp3');
-  chrome.scripting.executeScript({
-    target: { tabId },
-    args: [url],
-    func: (soundUrl) => {
-      const audio = new Audio(soundUrl);
-      audio.play().catch(() => {});
-    }
-  });
-}
-
 chrome.webNavigation.onCompleted.addListener((details) => {
   if (details.frameId !== 0) return;
   if (!enabledTabs.has(details.tabId)) return;
   updateAction(details.tabId, true);
-  playSound(details.tabId);
+  chrome.scripting.executeScript({
+    target: { tabId: details.tabId },
+    args: [ chrome.runtime.getURL('sound.mp3') ],
+    func: (url) => {
+      console.log(url);
+      new Audio(url).play();
+    }
+  });
 });

--- a/background.js
+++ b/background.js
@@ -49,12 +49,14 @@ chrome.tabs.onRemoved.addListener((tabId) => {
   }
 });
 
-function showAlert(tabId) {
+function playSound(tabId) {
+  const url = chrome.runtime.getURL('sound.mp3');
   chrome.scripting.executeScript({
     target: { tabId },
-    func: () => {
-      // TODO: replace with sound or better UI
-      alert('Tab reloaded');
+    args: [url],
+    func: (soundUrl) => {
+      const audio = new Audio(soundUrl);
+      audio.play().catch(() => {});
     }
   });
 }
@@ -63,5 +65,5 @@ chrome.webNavigation.onCompleted.addListener((details) => {
   if (details.frameId !== 0) return;
   if (!enabledTabs.has(details.tabId)) return;
   updateAction(details.tabId, true);
-  showAlert(details.tabId);
+  playSound(details.tabId);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -10,5 +10,11 @@
   },
   "action": {
     "default_title": "Toggle Reload Alert"
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [ "sound.mp3" ],
+      "matches": [ "*://*/*" ]
+    }
+  ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Page Reload Alert",
-  "description": "Plays a notification when an enabled tab reloads.",
+  "description": "Plays a sound when an enabled tab reloads.",
   "version": "1.0",
   "permissions": ["tabs", "storage", "scripting", "webNavigation"],
   "host_permissions": ["*://*/*"],


### PR DESCRIPTION
## Summary
- play sound effect via content script when a watched tab reloads
- update README to mention sound
- clarify manifest description

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684964600a348331a6cfd94e8c9a4ea1