### PR TITLE
Improve notification info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Page Load Alert Chrome Extension
 
-This extension displays a notification whenever a tab reloads and the extension is enabled for that tab.
+This extension displays a notification whenever a tab reloads and the extension is enabled for that tab. The notification indicates which tab reloaded and uses the tab's favicon as the icon when available.
 
 ## Installation
 1. Open Chrome and navigate to `chrome://extensions`.
@@ -10,5 +10,5 @@ This extension displays a notification whenever a tab reloads and the extension 
 ## Usage
  - Click the extension's toolbar icon to toggle reload alerts for the active tab.
 - When enabled, the badge displays **ON** and stays visible even after the page reloads.
-- A notification will appear each time the page reloads on that tab.
+- A notification will appear each time the page reloads on that tab. It shows the page title and uses the favicon as the notification icon.
 - The setting is disabled by default and remembered per tab until the tab is closed.

--- a/background.js
+++ b/background.js
@@ -36,12 +36,12 @@ chrome.webNavigation.onCompleted.addListener((details) => {
     updateAction(details.tabId, true);
     chrome.tabs.get(details.tabId, (tab) => {
       const iconUrl = tab.favIconUrl || chrome.runtime.getURL('progress-check.png');
-      const title = tab.title || 'The page';
+      const title = `"${tab.title}"` || 'The tab';
       chrome.notifications.create({
         type: 'basic',
         iconUrl,
         title: 'Tab Reloaded',
-        message: `"${title}" has finished loading.`
+        message: `${title} has finished loading.`
       });
     });
   }

--- a/background.js
+++ b/background.js
@@ -34,11 +34,15 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 chrome.webNavigation.onCompleted.addListener((details) => {
   if (details.frameId === 0 && enabledTabs.has(details.tabId)) {
     updateAction(details.tabId, true);
-    chrome.notifications.create({
-      type: 'basic',
-      iconUrl: chrome.runtime.getURL('progress-check.png'),
-      title: 'Tab Reloaded',
-      message: 'The page has finished loading.'
+    chrome.tabs.get(details.tabId, (tab) => {
+      const iconUrl = tab.favIconUrl || chrome.runtime.getURL('progress-check.png');
+      const title = tab.title || 'The page';
+      chrome.notifications.create({
+        type: 'basic',
+        iconUrl,
+        title: 'Tab Reloaded',
+        message: `"${title}" has finished loading.`
+      });
     });
   }
 });


### PR DESCRIPTION
## Summary
- show the page title and favicon when a reload notification fires
- update docs with new behavior

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684997b092608331b7f8716e551edb5c